### PR TITLE
Permitir configurar el CUPS (para cuando se tienen varios contratos)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ sensor:
     username: "username sin comillas"
     password: "password sin comillas"
     #scan_interval: 60 #This is in seconds. Mejor no usar para evitar baneos
+    #cups: XXXXX #Establecer cuando se tienen varios CUPS para selecionar de cual de ellos obtener los datos
 ```
 
  

--- a/example.py
+++ b/example.py
@@ -8,13 +8,23 @@ Created on Wed May 20 11:51:36 2020
 """
 USER = ''
 PASSWORD = ''
+CUPS = ''
 
 from backend.EdistribucionAPI import Edistribucion
+
+
 
 edis = Edistribucion(USER,PASSWORD)
 edis.login()
 r = edis.get_cups()
-cups = r['data']['lstCups'][0]['Id']
-print('Cups: ',cups)
-meter = edis.get_meter(cups)
+print(r)
+
+if CUPS:
+    for c in r['data']['lstCups']:
+        if c['Name'] == CUPS:
+            cups_id = c['Id']
+else:
+    cups_id = r['data']['lstCups'][0]['Id']
+print('Cups id: ',cups_id)
+meter = edis.get_meter(cups_id)
 print('Meter: ',meter)


### PR DESCRIPTION
He añadido un nuevo parámetro `cups` a la configuración para poder configurar el CUPS en casos en los que se tienen varios, para poder establecer de cual de ellos se quiere obtener la información.

Este parámetro es opcional, en caso de no establecerlo o dejarlo vacío, se comportará como hasta ahora